### PR TITLE
Add BrowserBash to AI-based Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Browser automation frameworks and end-to-end testing ecosystems.
 - [TestRigor](https://testrigor.com/). Describe end-to-end tests in natural language.
 - [TestersAI](https://www.testersai.com/). Mysterious claims to be "converting the brains of the best testers into AI".
 - [Octomind](https://www.octomind.dev/). Auto-generated, run and maintained Playwright tests with AI-assisted test case discovery.
+- [BrowserBash](https://github.com/PramodDutta/browserbash). Open-source CLI: describe browser tests in plain English, an AI agent runs them in a real Chrome and returns deterministic assertions + CI exit codes. Ships an MCP server; runs on free local models.
   
 ## Enterprise Platforms
 


### PR DESCRIPTION
Adds **BrowserBash** to AI-based Testing (beside TestRigor / Octomind).

- Repo: https://github.com/PramodDutta/browserbash (Apache-2.0, open-source)

Like TestRigor you describe tests in natural language, but BrowserBash is open-source, runs on free local models (no API keys), and ships an MCP server so AI coding agents can validate their own UI work. Returns deterministic assertions + CI exit codes. One-line addition matching the section format.