### PR TITLE
Add QASkills.sh under AI-based Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Browser automation frameworks and end-to-end testing ecosystems.
 - [TestRigor](https://testrigor.com/). Describe end-to-end tests in natural language.
 - [TestersAI](https://www.testersai.com/). Mysterious claims to be "converting the brains of the best testers into AI".
 - [Octomind](https://www.octomind.dev/). Auto-generated, run and maintained Playwright tests with AI-assisted test case discovery.
+- [QASkills.sh](https://qaskills.sh). Open registry of 400+ QA testing skills that AI coding agents (Claude Code, Cursor, and 30+ others) install and follow via the qaskills CLI.
   
 ## Enterprise Platforms
 


### PR DESCRIPTION
Adds [QASkills.sh](https://qaskills.sh) to the **AI-based Testing** section.

QASkills.sh is an open, MIT-licensed registry of 400+ QA and testing skills (Playwright E2E, API testing, LLM evaluation, accessibility, performance) that AI coding agents install and follow via the `qaskills` CLI. It works with Claude Code, Cursor, and 30+ other agents.

- Site: https://qaskills.sh
- Source: https://github.com/PramodDutta/qaskills

Single-line addition, matches the existing entry format.