### PR TITLE
Add Kane CLI to AI-based Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Browser automation frameworks and end-to-end testing ecosystems.
 - [TestRigor](https://testrigor.com/). Describe end-to-end tests in natural language.
 - [TestersAI](https://www.testersai.com/). Mysterious claims to be "converting the brains of the best testers into AI".
 - [Octomind](https://www.octomind.dev/). Auto-generated, run and maintained Playwright tests with AI-assisted test case discovery.
+- [Kane CLI](https://www.testmuai.com/kane-cli/). Natural-language browser tests from the terminal, returning pass/fail with shareable run evidence. From TestMu AI (formerly LambdaTest).
   
 ## Enterprise Platforms
 


### PR DESCRIPTION
@malomarrec Adds [Kane CLI](https://www.testmuai.com/kane-cli/) under AI-based Testing, next to TestRigor and Octomind which solve a similar problem. It runs browser tests from natural-language objectives in the terminal and returns pass/fail with a shareable evidence link. Your guidelines ask for familiarity with the tool — mine comes from building it: I work on Kane CLI at TestMu AI (formerly LambdaTest, which is already in your Enterprise Platforms section), so this is a vendor submission and entirely your call. sparshk@testmuai.com if useful.