### PR TITLE
Add Qualflare to Test Case Management and Reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,4 @@ Browser automation frameworks and end-to-end testing ecosystems.
 - [Tesults](https://www.tesults.com/). Web-based test reporting and case management platform.
 - [Allure](https://qameta.io/allure-report/). Open-source reporting platform with self-host and enterprise options. ![Allure stars](https://img.shields.io/github/stars/allure-framework/allure2?style=flat-square&logo=github&labelColor=%230D1117&color=%23161B22)
 - [TestDino](https://testdino.com/). A test reporting, intelligence, and management platform that turns noisy automated runs into centralized dashboards, AI-classified failures, and scheduled reports so teams can understand, act on, and govern their test suites with far less manual effort.
+- [Qualflare](https://qualflare.com/). AI test management and observability platform: history-based flaky-test detection, failure clustering by root cause, and release-risk scoring across 23 frameworks.


### PR DESCRIPTION
Adds [Qualflare](https://qualflare.com/) to **Test Case Management and Reporting**.

Qualflare is my SaaS — an AI test management & observability platform (history-based flaky-test detection, failure clustering by root cause, and release-risk scoring across 23 frameworks). It sits in the same category as the existing entries (TestDino, Tesults, Testrail). Happy to tweak the wording.
