### PR TITLE
Add sms-florin (SMS/OTP testing) to Test Data & Account Verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Browser automation frameworks and end-to-end testing ecosystems.
 - [Sauce Labs](https://saucelabs.com/).
 - [Smart Bear](https://smartbear.com/).
 
+## Test Data & Account Verification
+
+- [sms-florin](https://flo-voice1.com). Rents real UK phone numbers (physical GOIP hardware on EE/Three, not a reseller API) to receive SMS/OTP codes programmatically — useful for CI/QA suites that need to test WhatsApp, Telegram, Google, Discord or other SMS-verification flows without burning a personal number. REST API + [npm SDK](https://github.com/flovoice53-tech/sms-florin-sdk).
+
 ## Test Case Management and Reporting
 
 - [Xray](https://www.getxray.app/).


### PR DESCRIPTION
Adds sms-florin, a service that rents real UK phone numbers (physical GOIP hardware on EE/Three networks, not a reseller API) to receive SMS/OTP codes programmatically. Useful for CI/QA suites that need to exercise SMS-verification flows (WhatsApp, Telegram, Google, Discord, etc.) without tying up a personal phone number. Ships a REST API and an npm SDK (`sms-florin`).

Added a new 'Test Data & Account Verification' section since nothing quite fit the existing categories — happy to fold it into an existing section instead if you'd prefer.