### PR TITLE
Add Waterfall AI Test to AI-based Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Browser automation frameworks and end-to-end testing ecosystems.
 - [TestRigor](https://testrigor.com/). Describe end-to-end tests in natural language.
 - [TestersAI](https://www.testersai.com/). Mysterious claims to be "converting the brains of the best testers into AI".
 - [Octomind](https://www.octomind.dev/). Auto-generated, run and maintained Playwright tests with AI-assisted test case discovery.
+- [Waterfall AI Test](https://github.com/jiongfeng/waterfall-ai-test-platform). Open-source visual workbench for Playwright Test Agents that turns requirements into editable plans, native Playwright tests, real-browser verification, and versioned execution evidence with human review and repair workflows.
   
 ## Enterprise Platforms
 


### PR DESCRIPTION
## Summary

Adds [Waterfall AI Test](https://github.com/jiongfeng/waterfall-ai-test-platform) to **AI-based Testing** with a neutral, factual description.

Waterfall AI Test is an Apache-2.0 visual workbench built around Playwright Test Agents. It turns requirements into editable plans and native Playwright tests, verifies them with the real Playwright runner, and keeps human review, repair, reverification, version history, and run evidence in one workflow.

## Evaluation links

- Repository: https://github.com/jiongfeng/waterfall-ai-test-platform
- Live demo: http://43.130.174.131:5000/ (login: `demouser` / `demouser`)
- English walkthrough: https://youtu.be/0xX1qA6q12c
- License: Apache-2.0
- Disclosure: I maintain this project.

The demo is a public shared environment; please use only non-sensitive data. The current Public Beta assumes trusted, single-tenant deployments and is not a hostile-code sandbox.

## Validation

- `git diff --check` passes.
- `npx -y awesome-lint README.md` reports the repository existing format/baseline issues; the new entry follows the surrounding list style.

@malomarrec